### PR TITLE
For #36073, reduce amount of caching in ShotgunModel

### DIFF
--- a/python/tk_multi_workfiles/file_form_base.py
+++ b/python/tk_multi_workfiles/file_form_base.py
@@ -191,9 +191,10 @@ class FileFormBase(QtGui.QWidget):
                 continue
 
             # create an entity model for this query:
-            fields = ["image", "description", "project", "name", "code"]
+            fields = []
             if entity_type == "Task":
-                fields += ["step", "entity", "content", "sg_status_list", "task_assignees"]
+                # Add so we can filter tasks assigned to the user only on the client side.
+                fields += ["task_assignees"]
 
             model = ShotgunEntityModel(entity_type, resolved_filters, hierarchy, fields, parent=self,
                                        bg_task_manager=self._bg_task_manager)

--- a/python/tk_multi_workfiles/my_tasks/my_tasks_model.py
+++ b/python/tk_multi_workfiles/my_tasks/my_tasks_model.py
@@ -40,7 +40,7 @@ class MyTasksModel(ShotgunEntityModel):
         self.extra_display_fields = extra_display_fields or []
         filters = [["project", "is", project],
                    ["task_assignees", "is", user]]
-        fields = ["image", "sg_status_list", "description", "entity", "content", "step", "project"]
+        fields = ["image", "entity", "content"]
         fields.extend(self.extra_display_fields)
 
         ShotgunEntityModel.__init__(self, "Task", filters, ["content"], fields, parent,

--- a/python/tk_multi_workfiles/work_area.py
+++ b/python/tk_multi_workfiles/work_area.py
@@ -205,23 +205,23 @@ class WorkArea(object):
         settings_to_find = ["saveas_default_name", "saveas_prefer_version_up", 
                             "version_compare_ignore_fields", "file_extensions"]
         resolved_settings = {}
+        app = sgtk.platform.current_bundle()
         try:
             if self._context:
                 resolved_settings = self._get_settings_for_context(self._context, templates_to_find, settings_to_find)
         except:
-            # (TODO) - propogate problems up - maybe add an is_valid() method?
-            pass
+            app.log_exception("There was an error parsing the settings for context '%s'" % self._context)
         finally:
             # update the templates and settings regardless if an exception was raised.
             #
-            
+
             # update templates:
             self.work_area_template = resolved_settings.get("template_work_area")
             self.work_template = resolved_settings.get("template_work")
             self.publish_area_template = resolved_settings.get("template_publish_area")
             self.publish_template = resolved_settings.get("template_publish")
-            
-            # update other settings:        
+
+            # update other settings:
             self.save_as_default_name = resolved_settings.get("saveas_default_name", "")
             self.save_as_prefer_version_up = resolved_settings.get("saveas_prefer_version_up", False)
             self.version_compare_ignore_fields = resolved_settings.get("version_compare_ignore_fields", [])


### PR DESCRIPTION
The Workfiles application cached some unneeded fields for the treeview. This caused unnecessary tree rebuilds when something changed on the Shotgun server since the ShotgunModel considered the two datasets to be different and trigger a rebuild.
I also added basic error reporting of errors while reading an environment when searching for workfiles 2 settings.
Closes https://github.com/shotgunsoftware/tk-multi-workfiles2/pull/16